### PR TITLE
Fix matching combinations with modifierso

### DIFF
--- a/src/lib/listening/KeyCombination.js
+++ b/src/lib/listening/KeyCombination.js
@@ -263,6 +263,14 @@ class KeyCombination {
             stateFromEvent(event)
           );
         }
+
+        if (event[attributeName] === true && !modifierStillPressed) {
+          this.setKeyState(
+            modifierKey,
+            KeyEventType.keydown,
+            stateFromEvent(event)
+          );
+        }
       });
     })
   }

--- a/src/lib/shared/KeySequenceParser.js
+++ b/src/lib/shared/KeySequenceParser.js
@@ -138,7 +138,7 @@ class KeySequenceParser {
  */
 function parseCombination(string, options = {}) {
   const shiftPressed = string.indexOf(/[sS]hift/) !== -1;
-  const altPressed = string.indexOf(/[sS]hift/) !== -1;
+  const altPressed = string.indexOf(/[aA]lt/) !== -1;
 
   return string.replace(/^\+|(\s|[^+]\+)\+/, '$1plus').split('+').reduce((keyDictionary, keyName) => {
     let finalKeyName = standardizeKeyName(keyName, {

--- a/test/HotKeys/KeyCombinationsInvolvingCommand.spec.js
+++ b/test/HotKeys/KeyCombinationsInvolvingCommand.spec.js
@@ -66,4 +66,35 @@ describe('When a HotKeys key combination involves the command key:', () => {
       });
     })
   });
+
+  context(`and the keydown for the command key is missed`, () => {
+      beforeEach(function () {
+        this.keyMap = {
+          'ACTION1': { sequence: 'cmd+k', action: 'keydown' },
+        };
+
+        this.handler = sinon.spy();
+
+        this.handlers = {
+          'ACTION1': this.handler
+        };
+
+        this.reactDiv = document.createElement('div');
+        document.body.appendChild(this.reactDiv);
+
+        this.wrapper = mount(
+          <HotKeys keyMap={this.keyMap} handlers={this.handlers}>
+            <div className="childElement" />
+          </HotKeys>
+        );
+
+        this.targetElement = new FocusableElement(this.wrapper, '.childElement');
+        this.targetElement.focus();
+      });
+
+    it('still triggers the combination', function () {
+      this.targetElement.keyDown('k', {metaKey: true});
+      expect(this.handler).to.have.been.calledOnce;
+    });
+  });
 });


### PR DESCRIPTION
Steps:
1. Create a combination like "command+k"
2. Use command+tab to switch to the window of the application
3. Without releasing command, press "k"

Expected:
Shortcut triggers

Actual:
Since react hotkeys never saw the keydown for command, the shortcut does
not trigger.

We fix it!

Also there was a typo in KeySequenceParser -- none of the tests were
failing, and frankly have no idea what it changes, but is obviously a
bug.