### PR TITLE
🐛 Fix matching submatches when cmd held down

### DIFF
--- a/src/lib/matching/KeyCombinationMatcher.js
+++ b/src/lib/matching/KeyCombinationMatcher.js
@@ -207,8 +207,9 @@ function canBeMatched(keyCombination, combinationMatcher) {
   const combinationKeysNo = size(combinationMatcher.keyDictionary);
 
   const iterator = new KeyCombinationIterator(keyCombination);
+  const cmdIsHidingKeys = (combinationMatcher.keyDictionary.Meta && keyUpIsBeingHidden(keyCombination))
 
-  if (Configuration.option('allowCombinationSubmatches') || keyUpIsBeingHidden(keyCombination)) {
+  if (Configuration.option('allowCombinationSubmatches') || cmdIsHidingKeys) {
     return iterator.numberOfKeys >= combinationKeysNo;
   } else {
     /**

--- a/test/GlobalHotKeys/HoldingDownCmdWhilePressingOtherKeys.spec.js
+++ b/test/GlobalHotKeys/HoldingDownCmdWhilePressingOtherKeys.spec.js
@@ -12,6 +12,53 @@ describe('Holding down Cmd while pressing other keys:', function () {
     configure({allowCombinationSubmatches: false });
   });
 
+  describe('and there are not actions with combinations that involve Cmd', function() {
+    beforeEach(function () {
+      this.keyMap = {
+        ACTION1: "a",
+        ACTION2: "shift+b",
+      };
+
+      this.handler1 = sinon.spy();
+      this.handler2 = sinon.spy();
+
+
+      const handlers = {
+        ACTION1: this.handler1,
+        ACTION2: this.handler2,
+      };
+
+      this.reactDiv = document.createElement("div");
+      document.body.appendChild(this.reactDiv);
+
+      this.wrapper = mount(
+        <GlobalHotKeys keyMap={this.keyMap} handlers={handlers}>
+          <div className="childElement" />
+        </GlobalHotKeys>,
+        { attachTo: this.reactDiv }
+      );
+    });
+
+    afterEach(function() {
+      document.body.removeChild(this.reactDiv);
+    });
+
+    it('does not trigger unwanted events on single sequences', function () {
+      simulant.fire(this.reactDiv, "keydown", { key: KeyCode.COMMAND });
+      simulant.fire(this.reactDiv, "keydown", { key: KeyCode.A });
+
+      expect(this.handler1).not.to.have.been.called;
+    });
+
+    it('does not trigger unwanted events on combinations', function () {
+      simulant.fire(this.reactDiv, "keydown", { key: KeyCode.COMMAND });
+      simulant.fire(this.reactDiv, "keydown", { key: KeyCode.SHIFT });
+      simulant.fire(this.reactDiv, "keydown", { key: KeyCode.B });
+
+      expect(this.handler2).not.to.have.been.called;
+    });
+  });
+
   [true, false].forEach((allowCombinationSubmatches) => {
     describe(`when allowCombinationSubmatches is ${allowCombinationSubmatches}`, () => {
       before(function(){


### PR DESCRIPTION
Currently, holding down the `command` key short-circuits the `allowCombinationSubmatches` configuration due to the command key hiding keyup events. You can find more information about the reasoning [here]( https://github.com/ibash/react-hotkeys/blob/master/src/lib/config/Configuration.js#L110-L114).

This fix maintains that behaviour, however it only applies when the key map being compared against includes the `command` key.

Fixes https://github.com/greena13/react-hotkeys/issues/296
Fixes https://github.com/greena13/react-hotkeys/issues/234