### PR TITLE
Reduce performance overhead of verbose logging

### DIFF
--- a/src/lib/logging/EventStrategyLogger.js
+++ b/src/lib/logging/EventStrategyLogger.js
@@ -16,14 +16,14 @@ class EventStrategyLogger extends Logger {
     this.verbose(
       this.nonKeyEventPrefix(componentId),
       'New component options:\n',
-      printComponent(componentOptions)
+      () => printComponent(componentOptions)
     );
   }
 
   logKeyHistory(keyHistory, componentId) {
     this.verbose(
       this.keyEventPrefix(componentId),
-      `Key history: ${printComponent(keyHistory.toJSON())}.`
+      () => `Key history: ${printComponent(keyHistory.toJSON())}.`
     );
   }
 }

--- a/src/lib/logging/Logger.js
+++ b/src/lib/logging/Logger.js
@@ -66,7 +66,17 @@ class Logger {
         return;
       }
 
-      this[level] = ['debug', 'verbose'].indexOf(level) === -1 ? console[level] : console.log;
+      const logToConsole = ['debug', 'verbose'].indexOf(level) === -1 ? console[level] : console.log;
+
+      this[level] = (...args) => {
+        const materializedArgs = args.map(arg =>
+          // Function arguments are evaluated lazily to reduce performance overhead
+          typeof arg === 'function'
+            ? arg()
+            : arg
+        );
+        logToConsole(...materializedArgs);
+      }
     }
   }
 }

--- a/src/lib/matching/ActionResolver.js
+++ b/src/lib/matching/ActionResolver.js
@@ -132,7 +132,7 @@ class ActionResolver {
       this.logger.verbose(
         this.logger.keyEventPrefix(componentId),
         'Internal key mapping:\n',
-        `${printComponent(keyHistoryMatcher.toJSON())}`
+        () => `${printComponent(keyHistoryMatcher.toJSON())}`
       );
 
       const keyHistory = this._eventStrategy.keyHistory;

--- a/src/lib/strategies/AbstractKeyEventStrategy.js
+++ b/src/lib/strategies/AbstractKeyEventStrategy.js
@@ -149,7 +149,7 @@ class AbstractKeyEventStrategy {
     this.logger.verbose(
       this.logger.nonKeyEventPrefix(this.componentId, { focusTreeId: false }),
       'Registered component in application key map:\n',
-      `${printComponent(this.componentTree.get(this.componentId))}`
+      () => `${printComponent(this.componentTree.get(this.componentId))}`
     );
 
     return this.componentId;
@@ -176,7 +176,7 @@ class AbstractKeyEventStrategy {
     this.logger.verbose(
       this.logger.nonKeyEventPrefix(componentId),
       'Registered component mount:\n',
-      `${printComponent(this.componentTree.get(componentId))}`
+      () => `${printComponent(this.componentTree.get(componentId))}`
     );
   }
 
@@ -191,7 +191,7 @@ class AbstractKeyEventStrategy {
     this.logger.verbose(
       this.logger.nonKeyEventPrefix(componentId),
       'De-registered component. Remaining component Registry:\n',
-      `${printComponent(this.componentTree.toJSON())}`
+      () => `${printComponent(this.componentTree.toJSON())}`
     );
 
     if (this.componentTree.isRootId(componentId)) {


### PR DESCRIPTION
1) Log functions now accept function as an argument, which is lazily executed only when the particular logging level is actually enabled
2) Serialization of component tree in verbose logging is now done lazily using the above option